### PR TITLE
取得するツイートの重複を回避

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ import tweepy
 from dotenv import load_dotenv
 import os
 import slackweb
+import datetime
 
 load_dotenv()
 CONSUMER_KEY = os.getenv('CONSUMER_KEY')
@@ -24,14 +25,29 @@ def convert_status_to_url(status):
     return url
 
 
+# 2時間前～1時間前のツイートを取得するクエリ
+def create_query_by_time():
+    jst = datetime.timezone(datetime.timedelta(hours=+9), 'JST')
+    now = datetime.datetime.now(jst)
+    year = now.year
+    month = now.month
+    day = now.day
+    hour = now.hour
+
+    until = f'until:{year}-{month}-{day}_{hour - 1}:00:00_JST'
+    since = f'since:{year}-{month}-{day}_{hour - 2}:00:00_JST'
+
+    return f'{QUERY} {until} {since}'
+
+
 def get_tweets_by_query():
     auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
     auth.set_access_token(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
 
     api = tweepy.API(auth)
 
-    query = QUERY
-    tweets = api.search_tweets(q=query, result_type='recent')
+    query = create_query_by_time()
+    tweets = api.search_tweets(q=query, result_type='recent', count=100)
     tweets.reverse()
 
     return tweets


### PR DESCRIPTION
close: https://github.com/510t/twitterApp/issues/1

- heroku で一時間毎の定期実行としているため、一時間単位でツイートの取得日時を設定
- favが十分付くまでの猶予として1時間前から以前を取得